### PR TITLE
fixes for descriptions of known issues articles

### DIFF
--- a/known-issues/create-table.md
+++ b/known-issues/create-table.md
@@ -1,6 +1,6 @@
 ---
 title: CREATE TABLE permissions denied
-description: This article describes the error appearing in the ULS log that states that SPDocKit processes are trying to create tables in SharePoint databases.
+description: An error that appears in the ULS log, stating that SPDocKit processes are trying to create tables in SharePoint databases.
 author: Matija Hanzic  
 date: 28/8/2017
 ---

--- a/known-issues/custom-features-missing.md
+++ b/known-issues/custom-features-missing.md
@@ -1,11 +1,11 @@
 ---
 title: Custom features missing in reports
-description: This article describes the issue when custom features deployed on your farm are missing inside SPDocKit feature reports.
+description: Custom features deployed on your farm are missing in SPDocKit feature reports.
 author: Iva Novoselic  
 date: 25/5/2017
 ---
 
-__Summary:__ Custom features deployed on your farm are missing inside SPDocKit feature reports. If verbose logging is enabled inside SPDocKit Options, you will see the following errors in the Windows event logs:
+__Summary:__ Custom features deployed on your farm are missing in SPDocKit feature reports. If verbose logging is enabled inside SPDocKit Options, you will see the following errors in the Windows event logs:
 
 `Microsoft.SharePoint.SPException: Failed to find the XML file at location ’14\Template\Features\CustomFeatureName\feature.xml’`
 

--- a/known-issues/data-retention.md
+++ b/known-issues/data-retention.md
@@ -1,6 +1,6 @@
 ---
 title: Data retention not working properly
-description: This article describes a known issue related to the data retention not working properly.
+description: Data retention is not working properly.
 author: Iva Novoselic  
 date: 25/5/2017
 ---

--- a/known-issues/distributed-cache.md
+++ b/known-issues/distributed-cache.md
@@ -1,13 +1,13 @@
 ---
 title: Distributed Cache loading issue
-description: This article explains loading issue when Distributed Cache settings cannot be loaded onto a server because that is not part of a Distributed Cache Cluster.
+description: Distributed Cache settings cannot be loaded because the server is not part of the Distributed Cache Cluster.
 author: Iva Novoselic  
 date: 25/5/2017
 ---
 
 __Summary:__ SPDocKit does not load Distributed Cache settings data and displays a warning message during the load:
 
-`Distributed Cache settings cannot be loaded onto a server that is not part of a Distributed Cache Cluster.`
+`Distributed Cache settings cannot be loaded on a server that is not part of a Distributed Cache Cluster.`
 
 This happens because SPDocKit queries only the server it is installed on for Distributed Cache data, so if the server on which SPDocKit is running is not a host for the Distributed Cache service, no data will be loaded.
 

--- a/known-issues/forms-authentication-on-prem.md
+++ b/known-issues/forms-authentication-on-prem.md
@@ -1,11 +1,11 @@
 ---
 title: SharePoint On-Premises Forms Authentication 
-description: This article describes the issue of SPDocKit Workstation not supporting forms authentication when connecting to SharePoint On-Premises.
+description: SPDocKit Workstation does not support forms authentication when connecting to SharePoint On-Premises.
 author: Iva Novoselic  
 date: 25/5/2017
 ---
 
-__Summary:__ SPDocKit does not support connecting to SharePoint On-Premises sites using the Forms authentication credentials. Only the Windows credentials are supported when trying to connect to SharePoint On-Premises sites from the SPDocKit workstation instance.
+__Summary:__ SPDocKit does not support connecting to SharePoint On-Premises sites using the Forms authentication credentials. Only Windows credentials are supported when trying to connect to SharePoint On-Premises sites from the SPDocKit workstation instance.
 
 __Application Version:__ 5.2.0 and newer
 

--- a/known-issues/load-crashes-nullexception.md
+++ b/known-issues/load-crashes-nullexception.md
@@ -1,6 +1,6 @@
 ---
 title: Load crashes with NullReference exception
-description: This article expalins the possible cause of the farm load crash with NullReference exception.
+description: The farm snapshot process crashes with a NullReference exception.
 author: Iva Novoselic  
 date: 25/5/2017
 ---
@@ -11,7 +11,7 @@ __Summary:__ Upon inspecting the event log after a failed load, the following ex
 at Acceleratio.SPDocKit.Administration.SharePointCrawler.#LJ.#CxF()`
 
 
-This happens when SPDocKit tries to enumerate the site collections in a Web application and, because of possible farm misconfigurations, they are not properly available using the SharePoint API. To confirm that this is the case, check your site collections using Central Administration and also by using Powershell.
+This happens when SPDocKit tries to enumerate site collections in a Web application and, because of possible farm misconfigurations, they are not properly available using the SharePoint API. To confirm that this is the case, check your site collections using Central Administration and also by using Powershell.
 
 `Get-SPWebApplication [WebAppUrl] | Get-SPSite –Limit All`
 
@@ -19,6 +19,6 @@ You should see a discrepancy between the two lists if this is indeed the reason 
 
 __Application Version:__ 3.0.0 and newer
 
-__Solution:__ Please check your farm and site collections for any misconfigurations. One of the causes could be a missing managed path or a managed path of the wrong type. If the issue persists, contact our support team for the more detailed troubleshooting.
+__Solution:__ Please check your farm and site collections for any misconfigurations. One of the causes could be a missing managed path or a managed path of the wrong type. If the issue persists, contact our support team for more detailed troubleshooting.
 
 __Status:__ Not resolved.

--- a/known-issues/load-windows-updates.md
+++ b/known-issues/load-windows-updates.md
@@ -1,11 +1,11 @@
 ---
 title: Available Windows updates
-description: This article describe show to handle issue when SPDocKit is unable to read list of available Windows updates.
+description: SPDocKit is unable to read the list of available Windows updates from your servers.
 author: Iva Novoselic  
 date: 25/5/2017
 ---
 
-__Summary:__ SPDocKit is unable to read list of the available Windows updates while taking a snapshot. This will occur on the servers without Internet access that are configured to get Windows updates directly from the Microsoft servers. The same problem may occur if the server is configured to use the Windows Server Update Services (WSUS) server but cannot reach it.
+__Summary:__ SPDocKit is unable to read list of available Windows updates while taking a snapshot. This will occur on servers without Internet access that are configured to get Windows updates directly from the Microsoft servers. The same problem may occur if the server is configured to use the Windows Server Update Services (WSUS) server but cannot reach it.
 
 __Application Version:__ 3.0.0
 

--- a/known-issues/permissions-wizard-issue.md
+++ b/known-issues/permissions-wizard-issue.md
@@ -1,6 +1,6 @@
 ---
 title: Permissions Wizard issue
-description: This article describes the issue appearing in Permissions wizards.
+description: SPDocKit Workstation's people picker cannot find some users when using the permission wizards.k
 author: Iva Novoselic  
 date: 25/5/2017
 ---

--- a/known-issues/powerpivot-load-filenotfound.md
+++ b/known-issues/powerpivot-load-filenotfound.md
@@ -1,6 +1,6 @@
 ---
 title: PowerPivot FileNotFoundException issue
-description: This article describes how to resolve loading issue with FileNotFoundException error message appearing.
+description: A FileNotFoundException error message keeps appearing during SPDocKit's snapshot process.
 author: Iva Novoselic  
 date: 25/5/2017
 ---

--- a/known-issues/spdockit-reporting-upa-changes.md
+++ b/known-issues/spdockit-reporting-upa-changes.md
@@ -1,12 +1,12 @@
 ---
 title: Unaccounted differences in the UPA settings
-description: This article describes a problem with incorrectly collecting User Profile Service Application data.
+description: User Profile Service Application data is incorrect.
 author: Tomislav Kunaj
 date: 5/6/2017
 ---
 
-__Summary:__ Information pertaining to the User Profile Service Application is not being loaded correctly. This happens if data is being collected during an audience compilation, which makes some of the data unavailable. The data will not be retrieved and the snapshot will show up as containing unaccounted changes in the User Profile Service Application.
+__Summary:__ Information about the User Profile Service Application is not being loaded correctly. This happens if data is being collected during an audience compilation, which makes some of the data unavailable. The data will not be retrieved and the snapshot will show up as containing unaccounted changes in the User Profile Service Application.
 
-__Solution:__ Manage the audience compilation schedule and SPDocKit snapshot schedule to not coincide with each other.
+__Solution:__ Manage the audience compilation schedule and the SPDocKit snapshot schedule so they do not occur at the same time.
 
 __Status:__ Not resolved.

--- a/known-issues/sql-cluster-support.md
+++ b/known-issues/sql-cluster-support.md
@@ -1,11 +1,11 @@
 ---
 title: SQL Clusters support
-description: This article describes the problem with information about SQL clusters missing inside SPDocKit documentation.
+description: Information about SQL clusters is missing in SPDocKit's documentation.
 author: Iva Novoselic  
 date: 25/5/2017
 ---
 
-__Summary:__ Information about SQL clusters is missing inside SPDocKit documentation. If your farm databases are using any high-availability solutions like database mirroring or AlwaysOn groups, SPDocKit will not include those details in the documentation. Only the SQL Server where the primary database is located will be shown by SPDocKit.
+__Summary:__ Information about SQL clusters is missing in SPDocKit's documentation. If your farm databases are using any high-availability solutions like database mirroring or AlwaysOn groups, SPDocKit will not include those details in the documentation. Only the SQL Server where the primary database is located will be shown by SPDocKit.
 
 __Application Version:__ 3.0.0 and newer
 

--- a/known-issues/subscription-storage-metrics.md
+++ b/known-issues/subscription-storage-metrics.md
@@ -1,17 +1,17 @@
 ---
 title: Storage Metrics report subscription
-description: This article describes a known issue related to Stroage Metrics subscriptions.
+description: The Storage Metrics report is unavailable for subscriptions.
 author: Iva Novoselic  
 date: 25/5/2017
 ---
 
-__Summary:__ The main reason that this report cannot be used as a subscription is the sheer volume of data that would result if we were to expand all of the data.
+__Summary:__ The main reason that this report cannot be used as a subscription is the sheer volume of data that would result if all nodes were to be expanded.
 
-Notice also that the Expand All command for this report is disabled. Every time a node in the report is expanded, we are querying SharePoint for that level of content. The performance hit is negligible if you expand it manually node by node. But if we were to expand it all at once, it would likely consume all the resources available. Also, the exported pdf would be quite large and not easily viewable.
+Notice that the Expand All command for this report is disabled. Every time a node in the report is expanded, the SharePoint API is queried for that content. The performance hit is negligible when expanding nodes manually, node by node. If we were to expand all the nodes at once, it would likely consume all resources available on the server. Also, the exported pdf would be large and not easily viewable.
 
-The only way that the subscription feature would work is if we were to limit the number of levels it could be expanded when sending a subscription. e.g. the site collection size level. Anything lower would trigger a lot of SharePoint calls.
+The only way that the subscription feature would work is if the number of levels it expanded were severely limited when sending a subscription. e.g. the site collection size level. Anything lower would risk triggering too many SharePoint calls.
 
-We believed that such a limiting feature to the subscription of this report would limit the usefulness of the report, so we scrapped the idea.
+We believe that limiting the report when used as a subscription in such a way would render it useless, so we decided to rather not have it available at all for subscriptions.
 
 __Application version:__ 5.0.1.
 


### PR DESCRIPTION
Fixed the wording in the descriptions of known issues articles. They do not follow a template anymore, but are now (I hope) clearer on the intent of the article.
Some wording has also been changed